### PR TITLE
chore(front): change to real setup method

### DIFF
--- a/front/README.md
+++ b/front/README.md
@@ -1,8 +1,8 @@
 # ucon-todo Front
 
 ```
-$ ./setup.sh
-$ ./test.sh
+$ npm install
+$ npm test
 ```
 
 ## Generate d.ts file from swagger.json


### PR DESCRIPTION
I think setup.sh and test.sh are unnecessary files.
NPM scripts prepares `preinstall`, `install` and `postinstall` also for `test`.
